### PR TITLE
[TASK] Adjust php- and sentry/sdk-version and update ErrorHandler

### DIFF
--- a/Classes/ErrorHandler.php
+++ b/Classes/ErrorHandler.php
@@ -7,6 +7,7 @@ use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Core\Bootstrap;
 use Neos\Flow\Security\Context as SecurityContext;
 use Neos\Flow\Utility\Environment;
+use Sentry\SentrySdk;
 use function Sentry\captureException;
 use function Sentry\configureScope;
 use function Sentry\init as initSentry;
@@ -40,11 +41,7 @@ class ErrorHandler
      */
     protected $userContextService;
 
-    /**
-     * Initialize the sentry client and environment detection agent
-     */
-    public function initializeObject()
-    {
+    public function __construct() {
         initSentry(['dsn' => $this->dsn]);
         $this->agent = new Agent();
     }
@@ -168,7 +165,7 @@ class ErrorHandler
      */
     protected function setReleaseContext(): void
     {
-        $client = Hub::getCurrent()->getClient();
+        $client = SentrySdk::getCurrentHub()->getClient();
         if ($this->release !== '' && $client) {
             $options = $client->getOptions();
             $options->setRelease($this->release);

--- a/composer.json
+++ b/composer.json
@@ -4,9 +4,9 @@
     "license": "MIT",
     "description": "A sentry client for the Flow framework",
     "require": {
-        "php": "~7.1",
+        "php": "~7.1 || ~8.0",
         "neos/flow": ">=5.0.0",
-        "sentry/sdk": "^2.0",
+        "sentry/sdk": "^3.1",
         "jenssegers/agent": "^2.6"
     },
     "autoload": {


### PR DESCRIPTION
In Neos Flow 7.0 the method initializeObject got removed and the creation of objects can be done with the constructor.